### PR TITLE
Replace __lt__ and __gt__ in --query #2

### DIFF
--- a/soprano_dipolar/soprano_dipolar.xml
+++ b/soprano_dipolar/soprano_dipolar.xml
@@ -41,7 +41,9 @@
                 --cutoff '$rss.cutoff'
             #end if
             $isonuclear
-            --query '$query'
+            #if $query:
+                --query '$query.replace("__gt__", ">").replace("__lt__", "<")'
+            #end if
             #if $sortby:
                 --sortby '$sortby'
             #end if

--- a/soprano_nmr/soprano_nmr.xml
+++ b/soprano_nmr/soprano_nmr.xml
@@ -44,7 +44,9 @@
                 --subset '$subset'
             #end if
             $reduce
-            --query '$query'
+            #if $query:
+                --query '$query.replace("__gt__", ">").replace("__lt__", "<")'
+            #end if
             #if $sortby:
                 --sortby '$sortby'
             #end if

--- a/soprano_plotnmr/soprano_plotnmr.xml
+++ b/soprano_plotnmr/soprano_plotnmr.xml
@@ -34,7 +34,9 @@
                 --subset '$subset'
             #end if
             $reduce
-            --query '$query'
+            #if $query:
+                --query '$query.replace("__gt__", ">").replace("__lt__", "<")'
+            #end if
             --plot_type 2D
             --xelement '$xelement'
             --yelement '$yelement'
@@ -124,6 +126,7 @@
         </data>
     </outputs>
     <tests>
+        <!-- 1 -->
         <test expect_num_outputs="1">
             <param name="input" value="ethanol.magres" ftype="txt"/>
             <param name="xelement" value="C"/>
@@ -135,6 +138,7 @@
                 </assert_contents>
             </output>
         </test>
+        <!-- 2 -->
         <test expect_num_outputs="1">
             <param name="input" value="ethanol.magres" ftype="txt"/>
             <param name="xelement" value="C"/>
@@ -143,6 +147,18 @@
             <param name="plot_file_format" value="svg"/>
             <!-- Allow lines_diff for date and (random) uids -->
             <output name="plot_png" file="defaults.svg" compare="diff" lines_diff="70"/>
+        </test>
+        <!-- 3: Query parameters replaced -->
+        <test expect_num_outputs="1">
+            <param name="input" value="ethanol.magres" ftype="txt"/>
+            <param name="xelement" value="C"/>
+            <param name="references" value="C:170"/>
+            <param name="query" value="MS_shielding &gt; 100 and MS_shielding &lt; 180"/>
+            <output name="plot_png">
+                <assert_contents>
+                    <has_size value="68800" delta="100"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help><![CDATA[


### PR DESCRIPTION
Approach to special characters in text inputs is to single quote in the `<command/>`, and `replace()` any of the dunder patterns present (these are put in place instead of special characters). This allows `>` and `<` in the `--query` argument, but if more are needed we can replace those as well as needed.

Closes #2 